### PR TITLE
Fix block list of blocks loading

### DIFF
--- a/src/com/kellerkindt/scs/SCSConfiguration.java
+++ b/src/com/kellerkindt/scs/SCSConfiguration.java
@@ -292,7 +292,7 @@ public class SCSConfiguration extends Configuration {
     public Collection<String> getBlockListBlocks () {
         // somewhere along the way the list got wiped,
         // so empty lists are going to be refilled
-        List<String> list = getForced(KEY_BLOCKLIST_BLOCKS, Collections.emptyList());
+        List<String> list = getForced(KEY_BLOCKLIST_BLOCKS, new ArrayList<>()); // not Collections.emptyList(), because getForced() will return an empty list
         if (list != null && !list.isEmpty()) {
             return list;
         }


### PR DESCRIPTION
Hello ! ^^
There is a problem when the plugin load the blocks whitelist / blacklist : It always reset it, because `Collections.emptyList()` has `List` type, which is not and instance of `ArrayList`. This is why `getForced()` returns an empty list.
Have a nice day ! :D